### PR TITLE
integrate create host form with api

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=https://api-staging.siteofrefuge.com

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,10 @@
 # Getting Started with Site of Refuge
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+## Prerequisites
+Befor you can start using the site of refuge, you need to add .env file.
+
+`.env.example` will show all the variables you need to set.
 
 ## Available Scripts
 

--- a/frontend/src/api.tsx
+++ b/frontend/src/api.tsx
@@ -4,11 +4,11 @@ import { InteractionStatus, InteractionRequiredAuthError } from '@azure/msal-bro
 import { msalConfig } from './authConfig';
 import { ApiDefinition } from './apiTypes';
 
-const domain = process.env.NODE_ENV === 'production' ?
-  'https://api-staging.siteofrefuge.com' : '';
+const domain = process.env.REACT_APP_API_URL
 
 export const APIS: {[key: string]: ApiDefinition} = {
   ADD_REFUGEE: { url: '/v1/refugees', method: 'POST' },
+  ADD_HOST: { url: '/v1/hosts', method: 'POST' },
   GET_REFUGEES: { url: '/v1/refugees', method: 'GET' }
   // Add further APIs here...
 }

--- a/frontend/src/authConfig.js
+++ b/frontend/src/authConfig.js
@@ -6,7 +6,7 @@ export const msalConfig = {
  
   },
   cache: {
-    cacheLocation: "sessionStorage", // This configures where your cache will be stored
+    cacheLocation: "localStorage", // This configures where your cache will be stored
     storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
   },
 };

--- a/frontend/src/authConfig.js
+++ b/frontend/src/authConfig.js
@@ -6,7 +6,7 @@ export const msalConfig = {
  
   },
   cache: {
-    cacheLocation: "localStorage", // This configures where your cache will be stored
+    cacheLocation: "sessionStorage", // This configures where your cache will be stored
     storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
   },
 };

--- a/frontend/src/components/HostSignupForm.tsx
+++ b/frontend/src/components/HostSignupForm.tsx
@@ -240,6 +240,7 @@ export default function RefugeeSignupForm({
             }
             disabled={!getValues('summary.availability.active')}
             showPopperArrow={true}
+            minDate={new Date()}
             dateFormat='dd-MM-yyyy'
           />
         </FormControl>

--- a/frontend/src/components/RefugeeSignupForm.tsx
+++ b/frontend/src/components/RefugeeSignupForm.tsx
@@ -72,12 +72,14 @@ export default function RefugeeSignupForm({ onSignup } : { onSignup: () => void}
 
   const restrictions = useController({
     control,
-    name: 'summary.restrictions'
+    name: 'summary.restrictions',
+    defaultValue: []
   });
 
   const languages = useController({
     control,
-    name: 'summary.languages'
+    name: 'summary.languages',
+    defaultValue: []
   });
 
   

--- a/frontend/src/styles/react-datepicker.css
+++ b/frontend/src/styles/react-datepicker.css
@@ -20,7 +20,12 @@
   background-color: var(--chakra-colors-gray-300);
   
 }
-
+.react-datepicker__day.react-datepicker__day--disabled {
+  color: var(--chakra-colors-gray-300);
+}
+.react-datepicker__day--keyboard-selected {
+  background-color: transparent;  
+}
 /* if you dont want to use chakra's theme use this class in the wrapping div. These are the exact original values */
 .light-theme-original {
   --light-gray: #cccccc;


### PR DESCRIPTION
1. Added `.env.example` to configure BACKEND API easier more easily
2. We need to define `defaultValue: [],` for some fields `restrictions`, `languages` if we wont define it, server will respond with 400